### PR TITLE
add auth scheme request body

### DIFF
--- a/lib/omniauth/strategies/linkedin.rb
+++ b/lib/omniauth/strategies/linkedin.rb
@@ -8,7 +8,8 @@ module OmniAuth
       option :client_options, {
         :site => 'https://api.linkedin.com',
         :authorize_url => 'https://www.linkedin.com/oauth/v2/authorization?response_type=code',
-        :token_url => 'https://www.linkedin.com/oauth/v2/accessToken'
+        :token_url => 'https://www.linkedin.com/oauth/v2/accessToken',
+        :auth_scheme => 'request_body'
       }
 
       option :scope, 'r_liteprofile r_emailaddress'
@@ -130,7 +131,7 @@ module OmniAuth
       def profile_endpoint
         "/v2/me?projection=(#{ fields.join(',') })"
       end
-      
+
       def token_params
         super.tap do |params|
           params.client_secret = options.client_secret


### PR DESCRIPTION
Uprading `oauth2`to version 2.0.9 https://rubygems.org/gems/oauth2/versions/2.0.9 introduces breaking changes with `:auth_scheme`. The default value in 2.X.X is `:basic_auth` but it used to be `:request_body` in 1.X.X https://github.com/oauth-xx/oauth2/blob/main/lib/oauth2/client.rb#L54 and notes here https://github.com/oauth-xx/oauth2/tree/main?tab=readme-ov-file#what-is-new-for-v20 

Default value in 1.X.X https://gitlab.com/oauth-xx/oauth2/-/blob/1-4-stable/lib/oauth2/client.rb?ref_type=heads#L44

Some integrations still rely on `request_body` and linkedin is one of them so adding this